### PR TITLE
Add badge border radius variable to dark mode

### DIFF
--- a/custom_components/ha95/www/ha95.js
+++ b/custom_components/ha95/www/ha95.js
@@ -183,6 +183,7 @@ const RETRO_THEME_DARK = {
   "--ha-border-radius-6xl": "0",
   "--ha-border-radius-pill": "0",
   "--ha-border-radius-circle": "0",
+  "--ha-badge-border-radius": "0",
 
   // Fonts
   "--ha-font-family-body":


### PR DESCRIPTION
Following up on my previous PR, I missed adding the badge border radius fix to dark mode. Here's the fix there.

Before: 
<img width="568" height="144" alt="image" src="https://github.com/user-attachments/assets/fcaa67b1-3606-4595-bd16-cf2513a0ac6a" />

After: 
<img width="574" height="144" alt="image" src="https://github.com/user-attachments/assets/8ed3cb1f-d097-4ffd-89c8-ac3e31251002" />
